### PR TITLE
Unlock rounded-quantity editing and harden error/UX paths

### DIFF
--- a/analytics_tracking.py
+++ b/analytics_tracking.py
@@ -2,6 +2,7 @@
 import json
 import os
 import sys
+import time
 from datetime import datetime, date, timezone
 from logging import exception
 from pathlib import Path
@@ -9,6 +10,10 @@ import structlog
 import requests
 
 basedir = Path(__file__).parent.resolve()
+
+LOG_RETENTION_DAYS = 30
+_LOGS_PRUNED = False
+
 
 def normalize_timestamp(ts: str) -> str:
     return ts.replace("T", " ").replace("Z", "+00")
@@ -20,6 +25,24 @@ def _desktop_data_dir(app_name: str) -> Path:
         return Path.home() / "Library" / "Application Support" / app_name
     else:
         return Path.home() / ".local" / "share" / app_name
+
+
+def _prune_old_logs(log_dir: Path) -> None:
+    """Delete analytics log files older than LOG_RETENTION_DAYS. Runs once per process."""
+    global _LOGS_PRUNED
+    if _LOGS_PRUNED:
+        return
+    _LOGS_PRUNED = True
+    cutoff = time.time() - (LOG_RETENTION_DAYS * 86400)
+    try:
+        for path in log_dir.glob("analytics_*.json"):
+            try:
+                if path.stat().st_mtime < cutoff:
+                    path.unlink()
+            except OSError as exc:
+                print(f"[warn] could not remove old analytics log {path}: {exc}")
+    except OSError as exc:
+        print(f"[warn] could not enumerate analytics logs in {log_dir}: {exc}")
 
 
 def log_user_event(data):
@@ -36,6 +59,7 @@ def log_user_event(data):
         log_dir = basedir / "logs" / "analytics"
 
     log_dir.mkdir(parents=True, exist_ok=True)
+    _prune_old_logs(log_dir)
     log_file = log_dir / f"analytics_{today_str}.json"
 
     # Ensure all required fields exist with default None if missing

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import atexit
 import csv
 import io
 import json
+import logging
 import os
 import shutil
 import sys
@@ -57,7 +58,7 @@ BG_DESKTOP_ENV = "BG_DESKTOP"
 DEFAULT_SECRET_KEY = "super-secret"
 DATABASE_FILENAME = "app.db"
 INFO_FILENAME = "info.json"
-APP_VERSION = "3.1.2"
+APP_VERSION = "4.5.1"
 DEFAULT_TIMEZONE = "Asia/Kolkata"
 REQUIRED_DB_TABLES = {"customer", "invoice", "invoice_item", "item"}
 BACKUP_DIRNAME = "backups"
@@ -340,7 +341,8 @@ def _get_earliest_invoice_created_at() -> Optional[datetime]:
     if isinstance(earliest, str):
         try:
             earliest = datetime.strptime(earliest, ISO_8601_UTC)
-        except Exception:
+        except (ValueError, TypeError) as exc:
+            logger.warning("Could not parse earliest invoice createdAt %r: %s", earliest, exc)
             return None
 
     return _ensure_utc(earliest)
@@ -371,6 +373,20 @@ def _validate_bill_token(submitted: str) -> bool:
         return False
     session.pop('bill_form_token', None)
     return True
+
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_commit(action_label: str) -> bool:
+    """Commit the current session; rollback and log on failure. Returns True on success."""
+    try:
+        db.session.commit()
+        return True
+    except Exception:
+        db.session.rollback()
+        logger.exception("DB commit failed during %s", action_label)
+        return False
 
 
 def _get_customer_bill_history(
@@ -1170,7 +1186,8 @@ def format_inr(value, places: int = 2) -> str:
     """Return Indian-style grouping (e.g., 12,34,567.89)."""
     try:
         amt = Decimal(str(value or 0)).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
-    except Exception:
+    except (InvalidOperation, ValueError, TypeError) as exc:
+        logger.warning("format_inr: could not parse %r: %s", value, exc)
         amt = Decimal('0.00')
 
     sign = '-' if amt < 0 else ''
@@ -1196,7 +1213,8 @@ def rounding_to_nearest_zero(amount):
     """Rounding number to nearest zero"""
     try:
         d = Decimal(str(amount))
-    except Exception:
+    except (InvalidOperation, ValueError, TypeError) as exc:
+        logger.warning("rounding_to_nearest_zero: could not parse %r: %s", amount, exc)
         d = Decimal('0')
     tens = (d / Decimal('10')).quantize(Decimal('1'), rounding=ROUND_HALF_UP)
     return float(tens * Decimal('10'))
@@ -1380,10 +1398,17 @@ def ensure_info_json():
 
 def loading_info():
     info_path = ensure_info_json()
-
-    with open(info_path, 'r', encoding='utf-8') as f:
-        json_loaded = json.load(f)
-        return json_loaded
+    try:
+        with open(info_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        logger.exception("Failed to load info.json at %s; using defaults", info_path)
+        return {
+            "app_name": APP_NAME,
+            "version": APP_VERSION,
+            "onboarding_complete": False,
+            "data": _default_info_sections(),
+        }
 
 
 def refresh_info_json():
@@ -1737,8 +1762,10 @@ def recover_page():
 def recover_customer(id):
     cust = customer.query.get_or_404(id)
     cust.isDeleted = False
-    db.session.commit()
-    flash('Customer recovered successfully.', 'success')
+    if not _safe_commit('recover customer'):
+        flash('Could not recover the customer. Please try again.', 'danger')
+    else:
+        flash('Customer recovered successfully.', 'success')
     return redirect(url_for('recover_page'))
 
 
@@ -1942,8 +1969,10 @@ def edit_user(customer_id):
 def recover_invoice(id):
     inv = invoice.query.get_or_404(id)
     inv.isDeleted = False
-    db.session.commit()
-    flash('Invoice recovered successfully.', 'success')
+    if not _safe_commit('recover invoice'):
+        flash('Could not recover the invoice. Please try again.', 'danger')
+    else:
+        flash('Invoice recovered successfully.', 'success')
     return redirect(url_for('recover_page'))
 
 
@@ -1951,8 +1980,10 @@ def recover_invoice(id):
 def recover_transaction(txn_id):
     txn = accountingTransaction.query.get_or_404(txn_id)
     txn.is_deleted = False
-    db.session.commit()
-    flash('Transaction recovered successfully.', 'success')
+    if not _safe_commit('recover transaction'):
+        flash('Could not recover the transaction. Please try again.', 'danger')
+    else:
+        flash('Transaction recovered successfully.', 'success')
     return redirect(url_for('recover_page'))
 
 
@@ -1996,9 +2027,8 @@ def config():
     layout_config = layoutConfig.get_or_create()
     layout_sizes = layout_config.get_sizes()
 
-    # --- Load existing info.json ---
-    with open(info_path, 'r', encoding='utf-8') as f:
-        info_data = json.load(f)
+    # --- Load existing info.json (with fallback if corrupted/missing) ---
+    info_data = loading_info()
 
     app_info = info_data.get("data", {})
     if not isinstance(app_info, dict):
@@ -3517,8 +3547,9 @@ def delete_customer(cid):
             if hasattr(inv, 'isDeleted'):
                 inv.isDeleted = True
                 inv.deletedAt = datetime.now(timezone.utc)
-        db.session.commit()
-        # add alert,
+        if not _safe_commit('cascade delete customer'):
+            flash('Could not delete the customer. Please try again.', 'danger')
+            return redirect(url_for('view_customers'))
         flash('Customer and related invoices deleted successfully.', 'danger')
         return redirect(url_for('view_customers'))
 
@@ -3534,8 +3565,10 @@ def delete_customer(cid):
     # No invoices -> delete immediately (GET or POST)
     if hasattr(c, 'isDeleted'):
         c.isDeleted = True
-        db.session.commit()
-        flash('Customer deleted.', 'danger')
+        if not _safe_commit('delete customer'):
+            flash('Could not delete the customer. Please try again.', 'danger')
+        else:
+            flash('Customer deleted.', 'danger')
     else:
         flash('Delete not available in this build.', 'warning')
 
@@ -4419,7 +4452,7 @@ def _build_bill_preview_context(current_invoice, *, include_due_summary=False, i
             qr_svg_base64 = None
             upi_url = None
     except Exception as e:
-        print(f"[ERROR] failed to fetch QR: {e}")
+        app.logger.warning("failed to fetch QR: %s", e)
         qr_svg_base64 = None
         upi_url = None
 
@@ -4636,8 +4669,9 @@ def edit_bill(invoicenumber):
         current_invoice.exclude_phone = request.form.get('exclude_phone') in ('on', 'true', '1')
         current_invoice.exclude_gst = request.form.get('exclude_gst') in ('on', 'true', '1')
         current_invoice.exclude_addr = request.form.get('exclude_addr') in ('on', 'true', '1')
-        db.session.commit()
-        # add alert - Not needed funcionally
+        if not _safe_commit('update invoice metadata'):
+            flash('Could not save invoice settings. Please try again.', 'danger')
+            return redirect(url_for('edit_bill', invoicenumber=current_invoice.invoiceId))
         return redirect(url_for('view_bill_locked', invoicenumber=current_invoice.invoiceId, edit_bill='true'))
 
     # Render the same template as create_bill.html but pre-filled
@@ -4670,8 +4704,9 @@ def delete_bill(invoicenumber):
     inv = invoice.query.filter_by(invoiceId=invoicenumber, isDeleted=False).first_or_404()
     inv.isDeleted = True
     inv.deletedAt = datetime.now(timezone.utc)
-    db.session.commit()
-    # add alert
+    if not _safe_commit('delete bill'):
+        flash('Could not delete the bill. Please try again.', 'danger')
+        return redirect(url_for('view_bills'))
     flash('Bill has been deleted.', 'danger')
 
     next_url = request.form.get('next') or ''
@@ -4693,8 +4728,8 @@ def update_bill(invoicenumber):
 
     submitted_token = request.form.get('form_token')
     if not _validate_bill_token(submitted_token):
-        flash('The bill form has expired. Please reopen the invoice before updating.', 'warning')
-        return redirect(url_for('view_bill_locked', invoicenumber=invoicenumber, edit_bill='true'))
+        flash('The bill form expired or was already submitted. Reopen the bill and make your changes again.', 'warning')
+        return redirect(url_for('edit_bill', invoicenumber=invoicenumber))
 
     # 2) Read form inputs
     descriptions = request.form.getlist('description[]')
@@ -4976,7 +5011,7 @@ def generate_qr():
             qr_svg_base64 = None
             upi_url = None
     except Exception as e:
-        print(f"[ERROR] failed to fetch QR: {e}")
+        app.logger.warning("failed to fetch QR: %s", e)
         qr_svg_base64 = None
         upi_url = None
 

--- a/templates/add_inventory.html
+++ b/templates/add_inventory.html
@@ -23,11 +23,10 @@
       <label for="name">Description</label>
     </div>
 
-    <div class="form-floating mb-1">
-      <input type="text" class="form-control shadow-sm" id="sku" placeholder="Auto-assigned" disabled>
-      <label for="sku">SKU (auto-assigned)</label>
+    <div class="alert alert-light border small d-flex align-items-center gap-2 py-2 mb-3" role="status">
+      <i class="bi bi-info-circle text-primary"></i>
+      <span><strong>SKU</strong> is generated automatically when you save the item.</span>
     </div>
-    <div class="form-text mb-3">SKU will be generated automatically when you save the item.</div>
 
     <div class="form-floating mb-3">
       <input type="number" class="form-control shadow-sm" id="unitPrice" name="unitPrice" placeholder="Unit Price" step="0.01" required>

--- a/templates/create_bill.html
+++ b/templates/create_bill.html
@@ -1070,6 +1070,7 @@ function setupRow(row) {
         rateInput.value = isNaN(v) ? priceMap[key] : v.toFixed(2);
         rateInput.dataset.autofilled = "true";
         row.dataset.lastEdited = 'rate';
+        clearRoundedState(row);
         calculateTotal();
       }
     }
@@ -1083,18 +1084,21 @@ function setupRow(row) {
     rateInput.addEventListener('input', () => {
       rateInput.dataset.autofilled = "false";
       row.dataset.lastEdited = 'rate';
+      clearRoundedState(row);
       calculateTotal();
     });
   }
   if (qtyInput) {
     qtyInput.addEventListener('input', () => {
       row.dataset.lastEdited = 'quantity';
+      clearRoundedState(row);
       calculateTotal();
     });
   }
   if (totalInput) {
     totalInput.addEventListener('input', () => {
       row.dataset.lastEdited = 'total';
+      clearRoundedState(row);
       calculateTotal();
     });
   }
@@ -1180,12 +1184,6 @@ function restoreRoundedState(row) {
   const roundedHidden = row.querySelector('input[type="hidden"][name="rounded[]"]');
   if (!roundedHidden || roundedHidden.value !== '1') return;
 
-  const qtyInput = row.querySelector('[name="quantity[]"]');
-  if (qtyInput) {
-    qtyInput.readOnly = true;
-    qtyInput.classList.add('bg-light');
-  }
-
   let existingMark = row.querySelector('.rounded-mark');
   if (!existingMark) {
     const tick = document.createElement('span');
@@ -1197,6 +1195,19 @@ function restoreRoundedState(row) {
     } else {
       row.appendChild(tick);
     }
+  }
+}
+
+function clearRoundedState(row) {
+  if (!row) return;
+  const roundedHidden = row.querySelector('input[type="hidden"][name="rounded[]"]');
+  if (roundedHidden) roundedHidden.value = '0';
+  const mark = row.querySelector('.rounded-mark');
+  if (mark) mark.remove();
+  const qtyInput = row.querySelector('[name="quantity[]"]');
+  if (qtyInput) {
+    qtyInput.readOnly = false;
+    qtyInput.classList.remove('bg-light');
   }
 }
 
@@ -1364,8 +1375,6 @@ document.addEventListener('DOMContentLoaded', () => {
       if (qty > 0) {
         rateInput.value = (rounded / qty).toFixed(2);
       }
-      qtyInput.readOnly = true;
-      qtyInput.classList.add("bg-light");
       row.dataset.lastEdited = 'total';
       let roundedHidden = row.querySelector('input[type="hidden"][name="rounded[]"]');
       if (roundedHidden) {
@@ -1409,8 +1418,6 @@ document.addEventListener('DOMContentLoaded', () => {
       if (qty > 0) {
         rateInput.value = (rounded / qty).toFixed(2);
       }
-      qtyInput.readOnly = true;
-      qtyInput.classList.add("bg-light");
       row.dataset.lastEdited = 'total';
       let roundedHidden = row.querySelector('input[type="hidden"][name="rounded[]"]');
       if (roundedHidden) {


### PR DESCRIPTION
## Summary
- Fixes a customer-reported bug: line items marked as rounded permanently locked their quantity field on edit. The lock is removed and the rounded flag now self-clears when qty/rate/total/description-autofill changes the row.
- Quality pass: wrap previously-unprotected `db.session.commit()` calls so failures roll back and flash an error instead of 500ing; redirect expired bill-edit form tokens back to the edit form (with a fresh token) rather than the locked view; replace silent `except Exception:` with narrow excepts + warning logs in three formatters; make `loading_info()` corruption-safe and route `/config` through it; prune analytics logs older than 30 days; sync `APP_VERSION` to `4.5.1` to match `build_exe.bat` and `version.txt`; replace the dead disabled SKU input on Add Inventory with a clear banner.

## Test plan
- [ ] Open an old bill that has a rounded line item, change its quantity — field should be editable, ✓ disappears, total recomputes from qty × rate.
- [ ] Repeat for rate edit, total edit, and description-driven rate autofill (create-mode only path).
- [ ] Click Round / Round All on a fresh bill; the qty stays editable; saving and reopening still shows ✓.
- [ ] Delete a bill / customer / recover a deleted record. Behaviour should be unchanged in the success path; if you can simulate a commit failure (lock the SQLite file on Windows) you should see a red flash, not a 500.
- [ ] Open `/edit-bill/<id>`, leave it idle past the form token lifetime (or open it twice and submit the older tab), submit — should land back on the edit form with a clear "expired or already submitted" flash, fresh token.
- [ ] Corrupt `info.json` (or temporarily rename it) and load `/config` — page should still render with default values rather than 500.
- [ ] Visit `/add_inventory` — confirm the SKU banner replaces the previous disabled input.
- [ ] Sanity: `/about` (or wherever `APP_VERSION` is shown) shows `4.5.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)